### PR TITLE
Making the REAMDME.md a bit more precise and general to use for other people

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+CMakeFiles
+CMakeCache.txt

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In order to build the following steps are neccesary.
  - Download AFLplusplus from the github repository:
    `git clone https://github.com/AFLplusplus/AFLplusplus`
  - build AFLplusplus by installing dependencies and executing `make`
- - change the path to your AFLplusplus git repository
+ - change the path to your AFLplusplus git repository inside of build.sh
  - execute the build.sh script inside this folder
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In order to build the following steps are neccesary.
 When you want to fuzz simply set the following env_variables prior to running AFLplusplus as usual:
 
 export AFL_CUSTOM_MUTATOR_ONLY=1
-export AFL_CUSTOM_MUTATOR_LIBRARY=~/Downloads/afl++/tree_mutation/js_parser/libTreeMutation.so
+export AFL_CUSTOM_MUTATOR_LIBRARY=[PATH to AFLplusplus]/js_parser/libTreeMutation.so
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ The AFLplusplus API the has been implemented in js_parser/TreeMutation.cpp.  Thi
 
 Building
 
-In order to build, execute the build.sh script inside this folder.
+In order to build the following steps are neccesary.
+
+ - Download AFLplusplus from the github repository:
+   `git clone https://github.com/AFLplusplus/AFLplusplus`
+ - build AFLplusplus by installing dependencies and executing `make`
+ - change the path to your AFLplusplus git repository
+ - execute the build.sh script inside this folder
 
 
 Running 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,37 @@
-Superion is a grammar mutator for AFLPlusPlus 
+# Superion
+
+Superion is a grammar mutator for AFLPlusPlus.
+It can be used to fuzz with specific grammars and make fuzzing more efficient for many targets.
+For more information about grammar Fuzzing see https://www.fuzzingbook.org/html/Grammars.html.
 
 
-Implementation details.
+## Implementation details.
 
-The AFLplusplus API the has been implemented in js_parser/TreeMutation.cpp.  This can be used to fuzz various languages such as javascript/php/jerryscript etc. See the Superion for more details, https://github.com/zhunki/Superion/ .
+The AFLplusplus API has been implemented in js_parser/TreeMutation.cpp.  This can be used to fuzz various languages such as javascript/php/jerryscript etc. See the Superion repository for more details, https://github.com/zhunki/Superion/ .
 
 
 
-Building
+## Building
 
 In order to build the following steps are neccesary.
 
  - Download AFLplusplus from the github repository:
-   `git clone https://github.com/AFLplusplus/AFLplusplus`
- - build AFLplusplus by installing dependencies and executing `make`
+   ```
+   git clone https://github.com/AFLplusplus/AFLplusplus
+   ```
+ - The current version of AFLplusplus is not supported by this repository. So you have to go into the AFLplusplus repository and change to tag 4.05c by typing
+   ```
+   git checkout tags/4.05c
+   ```
+ - build AFLplusplus by installing dependencies and executing
+   ```
+   make
+   ```
  - change the path to your AFLplusplus git repository inside of build.sh
  - execute the build.sh script inside this folder
 
 
-Running 
+## Running 
 
 When you want to fuzz simply set the following env_variables prior to running AFLplusplus as usual:
 

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ make -j16
 
 cd js_parser
 
-for f in *.cpp; do g++ -I ../runtime/src/ -I ~/Downloads/afl++ -c $f -fPIC -std=c++11 -fpermissive -Wattributes; done
+for f in *.cpp; do g++ -I ../runtime/src/ -I [Path to AFLplusplus] -c $f -fPIC -std=c++11 -fpermissive -Wattributes; done
 
 g++  -shared -std=c++11 *.o ../dist/libantlr4-runtime.a  -o libTreeMutation.so 
 

--- a/js_parser/TreeMutation.cpp
+++ b/js_parser/TreeMutation.cpp
@@ -8,7 +8,7 @@
 #include "include/config.h"
 #include "custom_mutators/examples/custom_mutator_helpers.h" 
 #include "config.h"
-#include "include/afl-fuzz.h"
+//#include "include/afl-fuzz.h"
 
 using namespace antlr4;
 using namespace std;

--- a/js_parser/TreeMutation.cpp
+++ b/js_parser/TreeMutation.cpp
@@ -6,7 +6,7 @@
 #include "ECMAScriptBaseVisitor.h"
 #include "ECMAScriptSecondVisitor.h"
 #include "include/config.h"
-#include "examples/custom_mutators/custom_mutator_helpers.h" 
+#include "custom_mutators/examples/custom_mutator_helpers.h" 
 #include "config.h"
 #include "include/afl-fuzz.h"
 


### PR DESCRIPTION
I like your approach to make the whole project with just one script.
However I was facing some difficulties when running it and after fixing them I thought I could contribute to the repo b creating a pull request with them.

### I changed the following:
 - fixed the location of the custom-mutator-helpers according to a newer version of AFL++
 - added all steps neccesary for building the project to the README.md
 - Added some styling to the README.de
 - Added a gitignore
 - replaced your path to AFLplusplus in the build.sh by a placeholder

### More changes I had no time to fix for now:
 - It would be awesome to adapt the repo to the newest AFLplusplus where there is no custom-mutator-helpers.h which is replaced by the afl-fuzz.h. This should not be too much work and if you like I can create a new pull-request sometime in January or February.